### PR TITLE
Update corpsetrig.tin

### DIFF
--- a/common/corpsetrig.tin
+++ b/common/corpsetrig.tin
@@ -54,7 +54,7 @@
             #var deathReport[mob_killer] %%1;
             _killerCheckIgnore;
         };
-
+        #delay 0 {
         #if !$fakeKill {
             #if {$corpsetrigKB} {
                 #if {"$deathReport[mob_killer]" == "$user_cap"} {corpse_trig}
@@ -100,7 +100,7 @@
             };
         };
     };
-            
+};
     #if $bot[active] {
         #showme {----- BOT REGISTERED KILL -----};
         #NOP #local lastItem &deathSummary[];


### PR DESCRIPTION
Realized that while i fixed this on my end awhile back, i never submitted it.

Discovered that corpsetrig-kb, which toggled between you character's kills, and all character killing blows, was not functioning correctly. having it set to your kills only resulted in corpse_trig never firing.
Adding a delay of 0 before the #if !$fakeKill conditional, this fixed the corpsetrig-kb, so now corpsetrig-kb can be toggled to only react to your killing blows.