### PR TITLE
Bot updates

### DIFF
--- a/common/areas/sectionz.tin
+++ b/common/areas/sectionz.tin
@@ -29,6 +29,7 @@
     #delay {4} {pause game};
     #delay {5} {play};
     #delay {6} {unpause};
+	#delay {7} {#map goto 25088};
 };
 
 #alias {set20} {
@@ -39,6 +40,7 @@
     #delay {4} {pause game};
     #delay {5} {play};
     #delay {6} {unpause};
+	#delay {7} {#map goto 24948};
 };
 
 #NOP -- MAKE BALANGOOL GEAR FROM SECTIONZ;

--- a/common/bot/bots.tin
+++ b/common/bot/bots.tin
@@ -4,7 +4,7 @@
 #read common/bot/bot_cycle.tin;
 
 #alias {.resume} {
-    #if {"$lastBot[rating]" == "Section Z"} {
+    #if {"$lastBot[area]" == "Section Z"} {
         #map run 24786;
         unpause game;
         #echo {10 seconds until $lastBot[rating] resumes...};

--- a/common/bot/generic.tin
+++ b/common/bot/generic.tin
@@ -99,6 +99,7 @@
         #var lastBot[file] $bot[file];
         #var lastBot[curVnum] $bot[curVnum];
         #var lastBot[pause_room] $bot[pause_room];
+        #var lastBot[rating] $bot[rating];
     };
 };
 

--- a/common/bot/generic.tin
+++ b/common/bot/generic.tin
@@ -99,7 +99,7 @@
         #var lastBot[file] $bot[file];
         #var lastBot[curVnum] $bot[curVnum];
         #var lastBot[pause_room] $bot[pause_room];
-        #var lastBot[rating] $bot[rating];
+        #var lastBot[area] $bot[area];
     };
 };
 


### PR DESCRIPTION
Updated sectionz.tin to include a map location assignment to set20 and set40, this should allow for use of +sectionz-20 and 40 respectively, instead of requiring -sectionz-20 and 2(in correct room, update map) and 40 respectively.

Also updated both generic.tin and bots.tin to use the $bot[area] element with reguards to .backupBot, this should allow .resume to bring you back to the correct room inside Section Z.

I have not rigged anything to allow you to start the section z bots outside the area.
